### PR TITLE
fix typo in error message

### DIFF
--- a/papermerge/core/views/nodes.py
+++ b/papermerge/core/views/nodes.py
@@ -266,7 +266,7 @@ def nodes_view(request):
             )
             msg += ", ".join([auto.name for auto in automates])
             msg += _(
-                ". Please delete mentioned Automates frist."
+                ". Please delete mentioned Automates first."
             )
 
             return msg, HttpResponseBadRequest.status_code


### PR DESCRIPTION
There was a small typo in an error message I stumbled upon. This PR fixes that typo. 

As far as I can see the only other mention of this typo is in 

https://github.com/papermerge/papermerge-core/blob/master/papermerge/core/locale/fr/LC_MESSAGES/django.po#L216

I do not know if it needs to be changed there aswell.