### PR TITLE
Fix imap.py

### DIFF
--- a/papermerge/core/importers/imap.py
+++ b/papermerge/core/importers/imap.py
@@ -268,7 +268,8 @@ def select_inbox(
 
 def email_iterator(
     imap_client: IMAPClient,
-    delete=False
+    delete=False,
+    trash_folder="Trash"
 ):
     """
     Generator used for lazy iteration over
@@ -306,10 +307,10 @@ def email_iterator(
         yield email_message
 
     if delete:
-        # mark e-mail as deleted, which should lead to a deletion for most mail providers
-        # Internally, delete_messages() will just call add_flags() with the flag br'\Deleted'
-        # Note: German mail provider 'Strato' won't delete messages after specifying the deleted flag, fix incoming
-        imap_client.delete_messages(messages)
+        # mark e-mail as read/seen to indicate that it has been successfully processed
+        imap_client.add_flags(messages, br'\Seen')
+        # move the mail to a trash folder
+        imap_client.move(messages, trash_folder)
 
 def import_attachment(
     imap_server: str,

--- a/papermerge/core/importers/imap.py
+++ b/papermerge/core/importers/imap.py
@@ -278,7 +278,7 @@ def email_iterator(
     Where email package is python standard (for python >= 3.6)
     library for managing email messages.
     """
-
+    
     if not isinstance(imap_client, IMAPClient):
         raise ValueError("Expecting IMAPClient instance as first argument")
 
@@ -300,11 +300,16 @@ def email_iterator(
             body,
             policy=email.policy.default
         )
+        # mark e-mail as read/seen, so that it won't be processed or imported multiple times
+        imap_client.add_flags(uid, br'\Seen')
+        
         yield email_message
 
     if delete:
+        # mark e-mail as deleted, which should lead to a deletion for most mail providers
+        # Internally, delete_messages() will just call add_flags() with the flag br'\Deleted'
+        # Note: German mail provider 'Strato' won't delete messages after specifying the deleted flag, fix incoming
         imap_client.delete_messages(messages)
-
 
 def import_attachment(
     imap_server: str,

--- a/papermerge/core/importers/imap.py
+++ b/papermerge/core/importers/imap.py
@@ -307,9 +307,9 @@ def email_iterator(
         yield email_message
 
     if delete:
-        # mark e-mail as read/seen to indicate that it has been successfully processed
+        # mark mails as read/seen to indicate successful processing
         imap_client.add_flags(messages, br'\Seen')
-        # move the mail to a trash folder
+        # move mails to a trash folder
         imap_client.move(messages, trash_folder)
 
 def import_attachment(

--- a/papermerge/core/importers/imap.py
+++ b/papermerge/core/importers/imap.py
@@ -268,8 +268,7 @@ def select_inbox(
 
 def email_iterator(
     imap_client: IMAPClient,
-    delete=False,
-    trash_folder="Trash"
+    delete=False
 ):
     """
     Generator used for lazy iteration over
@@ -307,10 +306,10 @@ def email_iterator(
         yield email_message
 
     if delete:
-        # mark mails as read/seen to indicate successful processing
-        imap_client.add_flags(messages, br'\Seen')
-        # move mails to a trash folder
-        imap_client.move(messages, trash_folder)
+        # flag all processed mails with \Deleted
+        imap_client.delete_messages(messages)
+        # remove all messages from the currently selected folder that have the \Deleted flag set
+        imap_client.expunge()
 
 def import_attachment(
     imap_server: str,


### PR DESCRIPTION
Update `email_iterator()` to mark processed mails as read/seen. This fixes the [following bug](https://github.com/ciur/papermerge/issues/233).

Append a final call to ``imap_client.expunge()`` after flagging processed mails as deleted by ``delete_messages()``. This ensures that all processed mails are properly deleted across various mail providers and should be a fix for [this](https://github.com/ciur/papermerge/issues/281) and of course [this](https://github.com/ciur/papermerge/issues/233).

~~For this pull request, if a user specifies the consumption option `IMPORT_MAIL_DELETE=True` to delete mails after processing, the mails will not be permanently deleted (as for papermerge-core 2.0.0.rc38), but marked as read and moved to the default folder `Trash` instead.~~

~~Users might specify a custom folder for 'deleted' mails in future releases as consumption option (e.g. ``IMPORT_MAIL_DELETE_FOLDER``). This is not implemented yet, since the variable ``trash_folder`` in `email_iterator()` is currently not overwritten by a user's variabe and per default set to the string `Trash`. Guess this will need a modification of [worker.py](https://github.com/papermerge/papermerge-core/blob/master/papermerge/core/management/commands/worker.py), correct?~~