### PR TITLE
use unique hostname variable name

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,7 +52,7 @@ Open your web browser and point it to http://papermerge.local address.
     PAPERMERGE_JS_IMAGE=papermerge/papermerge.js
     PAPERMERGE_JS_TAG=latest
 
-    HOSTNAME=papermerge.local
+    USE_HOSTNAME=papermerge.local
 
     DB_USER=postgres
     DB_NAME=postgres
@@ -73,7 +73,6 @@ Open your web browser and point it to http://papermerge.local address.
     SUPERUSER_PASSWORD=password
 
 
-Notice that ``HOSTNAME`` variable name from ``.env`` file should be same as hostname for papermerge
 instance from ``/etc/hosts``.
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,12 +31,12 @@ services:
     command: ws_server
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.ws_server.rule=Host(`${HOSTNAME}`) && PathPrefix(`/ws/`)"
+      - "traefik.http.routers.ws_server.rule=Host(`${USE_HOSTNAME}`) && PathPrefix(`/ws/`)"
   backend:  # rest api backend / uwsgi
     <<: *backend
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`${HOSTNAME}`) && PathPrefix(`/api/`)"
+      - "traefik.http.routers.backend.rule=Host(`${USE_HOSTNAME}`) && PathPrefix(`/api/`)"
   backend_init:
     <<: *backend
     depends_on:
@@ -75,7 +75,7 @@ services:
     image: ${PAPERMERGE_JS_IMAGE}:${PAPERMERGE_JS_TAG}
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.traefik.rule=Host(`${HOSTNAME}`) && PathPrefix(`/`)"
+      - "traefik.http.routers.traefik.rule=Host(`${USE_HOSTNAME}`) && PathPrefix(`/`)"
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     environment:


### PR DESCRIPTION
`$HOSTNAME` is not unique and may be overridden by shell environment, so I changed it to `USE_HOSTNAME` (there might be some better name, of course).

See https://github.com/papermerge/papermerge-core/issues/17#issuecomment-1145878439 for details and explanation.