### PR TITLE
models: Fix UnicodeDecodeError in Page.get_svg()

### DIFF
--- a/papermerge/core/models/page.py
+++ b/papermerge/core/models/page.py
@@ -344,7 +344,7 @@ class Page(models.Model):
         if not os.path.exists(svg_abs_path):
             raise IOError
 
-        with open(svg_abs_path, "r") as f:
+        with open(svg_abs_path, "rb") as f:
             data = f.read()
 
         return data


### PR DESCRIPTION
Fixes this exception on generating page previews:
```
ERROR 2022-08-07 21:07:02,110 log Internal Server Error: /api/pages/97bcb470-a668-482e-9d69-5b1693dc9862/
Traceback (most recent call last):
  File "/venv/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/venv/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/venv/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/venv/lib/python3.9/site-packages/django/views/generic/base.py", line 84, in view
    return self.dispatch(request, *args, **kwargs)
  File "/venv/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/venv/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/venv/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/venv/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/app/papermerge/core/views/pages.py", line 322, in get
    return self.retrieve(request, *args, **kwargs)
  File "/app/papermerge/core/views/pages.py", line 349, in retrieve
    data = instance.get_svg()
  File "/app/papermerge/core/models/page.py", line 350, in get_svg
    data = f.read()
  File "/usr/lib/python3.9/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 1217345: ordinal not in range(128)

```