### PR TITLE
Increase uwsgi socket-timeout

### DIFF
--- a/docker/prod/uwsgi.ini
+++ b/docker/prod/uwsgi.ini
@@ -7,3 +7,4 @@ workers = 2
 die-on-term = true
 threads = 4
 static-map = /static=/app/static
+socket-timeout = 30


### PR DESCRIPTION
Default 4 seconds seems to be to short for generating
8 pages previews on raspberry pi 4:

```
uwsgi_response_write_body_do() TIMEOUT !!!
OSError: write error
```