### PR TITLE
Add INDEX_NAME to HAYSTACK_CONNECTIONS for elasticsearch

### DIFF
--- a/docker/prod/config/settings.py
+++ b/docker/prod/config/settings.py
@@ -59,4 +59,5 @@ elif search_engine in (
     HAYSTACK_CONNECTIONS['default']['INDEX_NAME'] = config.get(
         'search',
         'index'
+        default='papermerge'
     )

--- a/docker/prod/config/settings.py
+++ b/docker/prod/config/settings.py
@@ -39,16 +39,24 @@ elif search_engine == 'whoosh':
         'path',
         default=os.path.join(PROJ_ROOT, 'whoosh_index')
     )
+elif search_engine == 'solr':
+    HAYSTACK_CONNECTIONS['default']['URL'] = config.get(
+        'search',
+        'url'
+    )
 elif search_engine in (
         'es7',
         'es',
         'elasticsearch7',
         'elasticsearch',
         'elastic',
-        'elastic7',
-        'solr'
+        'elastic7'
 ):
     HAYSTACK_CONNECTIONS['default']['URL'] = config.get(
         'search',
         'url'
+    )
+    HAYSTACK_CONNECTIONS['default']['INDEX_NAME'] = config.get(
+        'search',
+        'index'
     )


### PR DESCRIPTION
1. Seperated solr from es.
2. Add INDEX_NAME to HAYSTACK_CONNECTIONS
3. If no "PAPERMERGE__SEARCH__INDEX" is set, it will use 'papermerge' as index name