### PR TITLE
Fix wrong response code for file upload API call

### DIFF
--- a/docker/openapi-schema.yml
+++ b/docker/openapi-schema.yml
@@ -159,7 +159,7 @@ paths:
       security:
       - Token Authentication: []
       responses:
-        '200':
+        '201':
           description: No response body
   /api/documents/{id}/:
     get:


### PR DESCRIPTION
Hi,

while writing a python API client for papermerge, I stumbled upon an error where the response code for uploading a file via the API is actually returning a response code of 201, instead of 200.

As a sidenote:
I opened up a discussion topic on my API client here: https://github.com/ciur/papermerge/discussions/483

Thanks!