### PR TITLE
Enable multi-platform Docker builds in GitHub Actions - Update build-…

### DIFF
--- a/.github/workflows/build-standard-image.yml
+++ b/.github/workflows/build-standard-image.yml
@@ -34,4 +34,4 @@ jobs:
           push: true
           tags: papermerge/papermerge:${{ github.ref_name }}
           file: docker/standard/Dockerfile
-          platforms: linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/.github/workflows/build-standard-image.yml
+++ b/.github/workflows/build-standard-image.yml
@@ -34,4 +34,4 @@ jobs:
           push: true
           tags: papermerge/papermerge:${{ github.ref_name }}
           file: docker/standard/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64/v8


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to support building and pushing Docker images for multiple CPU architectures using Docker Buildx.

# What’s Changed
- Added docker/setup-buildx-action to enable Buildx for multi-platform builds.
- Updated docker/build-push-action to target the following platforms:

  - linux/amd64 (standard x86_64)
  - linux/arm64 (ARM64, e.g., newer Raspberry Pi)
  - linux/arm64/v8 (64-bit ARM v8 architecture)
  - linux/arm/v7 (32-bit ARM, e.g., Raspberry Pi 3 and earlier)

- Ensured the workflow pushes multi-platform images to Docker Hub.

# Why This Change?
The current Docker image is only built for a single CPU architecture, which limits its usability on ARM-based devices like Raspberry Pi. By enabling multi-platform builds, Papermerge becomes more accessible and deployable across a wider range of hardware platforms, including ARM64 and ARMv8 systems, without requiring emulation.

# How to Verify
- The workflow builds and pushes the Docker image for the following platforms:
  - linux/amd64
  - linux/arm64
  - linux/arm64/v8
  - linux/arm/v7
- Users on ARM and x86 systems can now pull and run the image natively.