### PR TITLE
Pipeline for ARM 64 only

### DIFF
--- a/.github/workflows/build-standard-image-arm64.yaml
+++ b/.github/workflows/build-standard-image-arm64.yaml
@@ -1,0 +1,39 @@
+name: Build Standard Image Arm64
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+a[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+.[0-9]+b[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+.[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+a[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+b[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+rc[0-9]+\-arm64'
+      - '[0-9]+.[0-9]+\-arm64'
+      - '[0-9]+\-arm64'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}  # checkout current branch
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build ${{ github.ref_name }} Prod Image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: papermerge/papermerge:${{ github.ref_name }}
+          file: docker/standard/Dockerfile
+          platforms: linux/arm/v7,linux/arm64/v8


### PR DESCRIPTION
Thank you @migueltsantana for bringing up the issue with ARM platform support.
This MR is continuation of #570.

Build for docker image for ARM platform should be in separate pipeline.
This merge request adds new pipeline designated only for building of arm docker images.

Currently [pipeline fails](https://github.com/papermerge/papermerge-core/actions/runs/12852330280/job/35834152211?pr=578) because [auth-server](https://github.com/papermerge/auth-server) docker image is amd64 only.

