### PR TITLE
Add support for Russian and Kazakh OCR languages

### DIFF
--- a/papermerge/core/features/tasks/schema.py
+++ b/papermerge/core/features/tasks/schema.py
@@ -26,6 +26,8 @@ LangCode = Literal[
     "ron",
     "san",
     "spa",
+    "kaz",
+    "rus",
 ]
 
 

--- a/ui2/src/cconstants.ts
+++ b/ui2/src/cconstants.ts
@@ -29,7 +29,9 @@ export const OCR_LANG: OCRLangType = {
   por: "Português",
   ron: "Română",
   san: "संस्कृत",
-  spa: "Español"
+  spa: "Español",
+  kaz: "Қазақша",
+  rus: "Русский"
 }
 
 export const HIDDEN = {

--- a/ui2/src/types.ts
+++ b/ui2/src/types.ts
@@ -281,6 +281,8 @@ export type OCRCode =
   | "ron"
   | "san"
   | "spa"
+  | "kaz"
+  | "rus"
 
 export type PageType = {
   id: string

--- a/ui2/src/types/ocr.ts
+++ b/ui2/src/types/ocr.ts
@@ -21,6 +21,8 @@ export type OCRCode =
   | "ron"
   | "san"
   | "spa"
+  | "kaz"
+  | "rus"
 
 export type OcrStatusEnum =
   | "UNKNOWN"


### PR DESCRIPTION
This PR adds support for Russian (rus) and Kazakh (kaz) OCR languages in Papermerge

This addresses the following issues:
- [#624](https://github.com/ciur/papermerge/issues/624)