### PR TITLE
Update GitHub Actions for image creation to support arm64/v8 CPUs

### DIFF
--- a/.github/workflows/build-standard-image.yml
+++ b/.github/workflows/build-standard-image.yml
@@ -36,4 +36,4 @@ jobs:
           push: true
           tags: papermerge/papermerge:${{ github.ref_name }}
           file: docker/standard/Dockerfile
-          platforms: linux/amd64. linux/arm64/v8
+          platforms: linux/amd64, linux/arm64/v8

--- a/.github/workflows/build-standard-image.yml
+++ b/.github/workflows/build-standard-image.yml
@@ -36,4 +36,4 @@ jobs:
           push: true
           tags: papermerge/papermerge:${{ github.ref_name }}
           file: docker/standard/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64. linux/arm64/v8


### PR DESCRIPTION
To continue building an image compatible with other architectures, I propose this amendment to include "arm64/v8" CPUs, following the previous attempt in #570.