### PR TITLE
[WIP] Support signed URLs for non-AWS object storage providers

### DIFF
--- a/papermerge/core/config.py
+++ b/papermerge/core/config.py
@@ -37,6 +37,13 @@ class Settings(BaseSettings):
     papermerge__ocr__automatic: bool = False
     papermerge__search__url: str | None = None
 
+    papermerge__s3__provider: str = "aws"
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_region_name: str | None = None
+    aws_endpoint_url: str | None = None
+    papermerge__s3__bucket_name: str | None = None
+
 settings = Settings()
 
 def get_settings():

--- a/papermerge/core/features/document/s3.py
+++ b/papermerge/core/features/document/s3.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from papermerge.core.types import ImagePreviewSize
 from papermerge.core import pathlib as plib
 from papermerge.core import config
+from papermerge.core.storage.factory import get_storage
 
 settings = config.get_settings()
 
@@ -12,17 +13,12 @@ VALID_FOR_SECONDS = 600
 
 
 def resource_sign_url(prefix, resource_path: Path):
-    from papermerge.core.cloudfront import sign_url
+    provider = get_storage()
 
-    encoded_path = quote(str(resource_path))
+    path = str(resource_path) if not prefix else f"{prefix}/{resource_path}"
 
-    if prefix:
-        url = f"https://{settings.papermerge__main__cf_domain}/{prefix}/{encoded_path}"
-    else:
-        url = f"https://{settings.papermerge__main__cf_domain}/{encoded_path}"
-
-    return sign_url(
-        url,
+    return provider.sign_url(
+        path,
         valid_for=VALID_FOR_SECONDS,
     )
 

--- a/papermerge/core/storage/aws.py
+++ b/papermerge/core/storage/aws.py
@@ -1,0 +1,15 @@
+from urllib.parse import quote
+
+from papermerge.core import config
+
+settings = config.get_settings()
+
+
+class AWSS3Storage:
+
+    def sign_url(self, path: str, valid_for: int) -> str:
+        from papermerge.core.cloudfront import sign_url as cf_sign_url
+
+        encoded_path = quote(str(path))
+        url = f"https://{settings.papermerge__main__cf_domain}/{encoded_path}"
+        return cf_sign_url(url, valid_for)

--- a/papermerge/core/storage/factory.py
+++ b/papermerge/core/storage/factory.py
@@ -1,0 +1,14 @@
+from papermerge.core import config
+from papermerge.core.storage.aws import AWSS3Storage
+from papermerge.core.storage.generic import GenericS3Storage
+
+settings = config.get_settings()
+
+
+def get_storage():
+    provider = settings.papermerge__s3__provider
+
+    if provider in ("minio", "vk"):
+        return GenericS3Storage()
+    else:
+        return AWSS3Storage()

--- a/papermerge/core/storage/generic.py
+++ b/papermerge/core/storage/generic.py
@@ -1,0 +1,24 @@
+import boto3
+
+from papermerge.core import config
+
+settings = config.get_settings()
+
+
+class GenericS3Storage:
+    def __init__(self):
+        self.client = boto3.client(
+            "s3",
+            aws_access_key_id=settings.aws_access_key_id,
+            aws_secret_access_key=settings.aws_secret_access_key,
+            region_name=settings.aws_region_name,
+            endpoint_url=settings.aws_endpoint_url,
+        )
+
+    def sign_url(self, path: str, valid_for: int) -> str:
+
+        return self.client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params={"Bucket": settings.papermerge__s3__bucket_name, "Key": path},
+            ExpiresIn=valid_for,
+        )


### PR DESCRIPTION
this pr adds support for generating signed URLs with aws s3 compatible storage providers

Added settings:
- `papermerge__s3__provider`
- `aws_access_key_id`, `aws_secret_access_key`, `aws_region_name`, `aws_endpoint_url`
- `papermerge__s3__bucket_name`

Added classes:
- `AWSS3Storage` – generates CloudFront signed URLs
- `GenericS3Storage` – uses boto3 for S3-compatible storage

Added factory method `get_storage()`

Updated `resource_sign_url` to use storage abstraction

refs [#14](https://github.com/papermerge/s3-worker/issues/14)